### PR TITLE
Single sample classification

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: medulloPackage
 Type: Package
 Title: Medulloblastoma Classifier
-Version: 0.1.0
+Version: 0.1.1
 Author: c(person("Pichai", "Raman", email = "ramanp@email.chop.edu",
     role = c("aut", "cre")),
     person("Komal", "Rathi", role = c("aut")))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Description: Goal of this project was to create a
 License: GPL-3 + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.2.3
 biocViews:
 Imports: 
     caret,

--- a/R/calcScore.R
+++ b/R/calcScore.R
@@ -53,7 +53,7 @@ calcScore <- function(myMat = NULL, mySetsUp = NULL) {
   }
 
   getScoreSet <- function(x, myMat = myMat) {
-    return(colMeans(myMat[rownames(myMat) %in% x,]))
+    return(colMeans(myMat[rownames(myMat) %in% x,,drop = F]))
   }
 
   myMatUp <- data.frame(lapply(mySetsUp, FUN = getScoreSet, myMat))

--- a/R/calcStats.R
+++ b/R/calcStats.R
@@ -61,7 +61,7 @@
   myScore <- sum(myClassPred==myClassActual)/(length(myClassActual)-sum(x)) # calculate accuracy score
   myScore <- format(myScore*100, digits = 2)
 
-  sampAnnot <- data.frame(myClassPred, myClassActual);
+  sampAnnot <- data.frame(myClassPred, myClassActual)
   sampAnnot[,"Correct"] <- myClassPred==myClassActual
   sampAnnot <- sampAnnot[sampAnnot[,2]!="U",]
   sampAnnot[,2] <- factor(sampAnnot[,2], levels=c("Group3", "Group4", "WNT", "SHH"))

--- a/R/classify.R
+++ b/R/classify.R
@@ -46,12 +46,6 @@ classify <- function(exprs = NULL, medulloGeneSetsUp = NULL) {
     medulloGeneSetsUp <- get(utils::data("medulloSetsUp"))
   }
 
-  # break if only 1 sample is supplied
-  if(ncol(exprs) == 1){
-    print("Cannot run correlations when only 1 sample is supplied. Rerun with at-least two samples!")
-    return(NULL)
-  }
-
   # calculate gene ratio matrix
   geneRatioOut <- signatureGenes(exprs)
 
@@ -60,7 +54,7 @@ classify <- function(exprs = NULL, medulloGeneSetsUp = NULL) {
   medulloGeneSetsUp$Group3 <- intersect(medulloGeneSetsUp$Group3, rownames(geneRatioOut))
   medulloGeneSetsUp$Group4 <- intersect(medulloGeneSetsUp$Group4, rownames(geneRatioOut))
 
-  myMat <- calcScore(geneRatioOut, medulloGeneSetsUp)
+  myMat <- calcScore(myMat = geneRatioOut, mySetsUp = medulloGeneSetsUp)
   pred <- myMat$pred
   pval <- myMat$pval
   sample.order <- rownames(pred)

--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ In order to run the package, you need two types of input:
 		* A vector of length M containing Medulloblastoma subtypes corresponding to each sample identifier. 
 		* Allowed values are **Group3, Group4, SHH, WNT and U (for Unknown)**
 
-*NOTE:* At least two samples are required for classification, as there is a step that includes calculating correlations. 
-
 There are two functions to run:
 
 	1. classify samples into medulloblastoma subtypes 
@@ -92,8 +90,21 @@ VMP1     10.329404  10.525463  10.342894  10.333212  10.787795
 
 
 # Run classifier
-> pred_109401 <- medulloPackage::classify(exprs_109401)
 
+# classify multiple samples together
+pred_109401 <- medulloPackage::classify(exprs = exprs_109401)
+
+# classify one sample at a time
+total <- data.frame()
+for(i in 1:ncol(exprs_109401)){
+  exprs <- exprs_109401[,i,drop = F]
+  pred <- classify(exprs = exprs)
+  total <- rbind(total, pred)
+}
+
+# check if the classification is identical? YES!
+identical(pred_109401, total)
+[1] TRUE
 
 # View output of classifier
 # predicted classes


### PR DESCRIPTION
I have made a few changes in the code to allow the capability for single-sample subtyping - which was long due. This will enable the dev team to be able to run the subtyping on each new sample individually without having to run it on existing classified samples.

Here are some tests that I have run to make sure that the single-sample subtyping output matches the multi-sample subtyping output:


**Dataset 1: GSE109401**

```
library(medulloPackage)
data("exprs_109401")

# classify multiple samples together
pred_109401 <- classify(exprs = exprs_109401)

# classify one sample at a time
total <- data.frame()
for(i in 1:ncol(exprs_109401)){
  exprs <- exprs_109401[,i,drop = F]
  pred <- classify(exprs = exprs)
  total <- rbind(total, pred)
}

# check if the classification output df is identical?
identical(pred_109401, total)
[1] TRUE
```

**Dataset 2: OpenPBTA**

```
setwd('~/Projects/OpenPBTA-analysis/analyses/molecular-subtyping-MB/')
suppressPackageStartupMessages({
  library(tidyverse)
  library(medulloPackage)
})

# set directories
root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
data_dir <- file.path(root_dir, "data")
clin <- read_tsv(file.path(root_dir, "data", "pbta-histologies-base.tsv"))
path_dx_list <- file.path("input", "mb_subtyping_path_dx_strings.json") %>%
  jsonlite::fromJSON()
clin.mb  <- clin %>%
  # Inclusion on the basis of strings in pathology_diagnosis and
  # if 'Other', then based on pathology_free_text_diagnosis
  filter(pathology_diagnosis %in% path_dx_list$exact_path_dx |
           (pathology_diagnosis == "Other" & str_detect(str_to_lower(pathology_free_text_diagnosis), 
                                                        paste0(path_dx_list$include_free_text, collapse = "|"))))

# MB RNA-seq samples only
clin.mb.rnaseq <- clin.mb %>%
  dplyr::filter(experimental_strategy == "RNA-Seq")

# fpkm dataset subsetted to MB RNA-seq samples
polya.mb <- file.path(root_dir, "data", "pbta-gene-expression-rsem-fpkm-collapsed.polya.rds") %>%
  readRDS() %>%
  dplyr::select(any_of(clin.mb.rnaseq$Kids_First_Biospecimen_ID))
stranded.mb <- file.path(root_dir, "data","pbta-gene-expression-rsem-fpkm-collapsed.stranded.rds") %>%
  readRDS() %>%
  dplyr::select(any_of(clin.mb.rnaseq$Kids_First_Biospecimen_ID))

# combine both polyA and stranded samples
all.exprs.mb <- polya.mb %>%
  rownames_to_column("gene") %>%
  inner_join(stranded.mb %>% rownames_to_column("gene"), by = "gene") %>%
  column_to_rownames('gene') %>%
  as.matrix()

# log2 transformation
all.exprs.mb <- log2(all.exprs.mb + 1)
dim(all.exprs.mb) 
# [1] 46303   122

# complete data
res <- medulloPackage::classify(exprs = all.exprs.mb)

# per sample classification
total <- data.frame()
for(i in 1:ncol(all.exprs.mb)){
  exprs <- all.exprs.mb[,i,drop = F]
  pred <- medulloPackage::classify(exprs = exprs)
  total <- rbind(total, pred)
}

# are both classifications identical?
> identical(res, total)
[1] TRUE

# output of a few samples
# multi-sample classification
> head(res)
                 sample best.fit      p.value
BS_S6Q7NKA3 BS_S6Q7NKA3      SHH 9.571056e-03
BS_09Z7TC35 BS_09Z7TC35   Group3 3.616578e-11
BS_1AYRM596 BS_1AYRM596   Group4 9.166351e-03
BS_1BWP5MCT BS_1BWP5MCT   Group3 7.040973e-10
BS_1QXEC43H BS_1QXEC43H      SHH 2.053227e-04
BS_1TWCV047 BS_1TWCV047   Group3 1.832252e-05

# single-sample classification
> head(total)
                 sample best.fit      p.value
BS_S6Q7NKA3 BS_S6Q7NKA3      SHH 9.571056e-03
BS_09Z7TC35 BS_09Z7TC35   Group3 3.616578e-11
BS_1AYRM596 BS_1AYRM596   Group4 9.166351e-03
BS_1BWP5MCT BS_1BWP5MCT   Group3 7.040973e-10
BS_1QXEC43H BS_1QXEC43H      SHH 2.053227e-04
BS_1TWCV047 BS_1TWCV047   Group3 1.832252e-05


```
